### PR TITLE
Fix event handler exception in the aggregate

### DIFF
--- a/core/lagompb-core/src/main/protobuf/lagompb/tests.proto
+++ b/core/lagompb-core/src/main/protobuf/lagompb/tests.proto
@@ -43,6 +43,16 @@ message TestFailCmd {
     string company_uuid = 1 [(lagompb.command).entity_id = true];
 }
 
+// Used to test event handler failure in the aggregate root
+message TestEventFailureCmd{
+    string company_uuid = 1 [(lagompb.command).entity_id = true];
+}
+
+// Event emitted to test event handler failure in the aggregate root
+message TestEventFailure{
+
+}
+
 message NoCmd {
 }
 

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -142,9 +142,9 @@ abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
             .withFailedReply(
               FailedReply()
                 .withReason(
-                  exception.getMessage
+                  s"[Lagompb] EventHandler failure: ${exception.getMessage}"
                 )
-                .withCause(FailureCause.ValidationError)
+                .withCause(FailureCause.InternalError)
             )
         )
 

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -3,7 +3,7 @@ package io.superflat.lagompb
 import java.time.Instant
 
 import akka.actor.ActorSystem
-import akka.actor.typed.Behavior
+import akka.actor.typed.{ActorRef, Behavior}
 import akka.cluster.sharding.typed.scaladsl.{EntityContext, EntityTypeKey}
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior, ReplyEffect, RetentionCriteria}
@@ -17,6 +17,7 @@ import io.superflat.lagompb.protobuf.core.CommandHandlerResponse.HandlerResponse
 }
 import io.superflat.lagompb.protobuf.core.SuccessCommandHandlerResponse.Response.{Event, NoEvent}
 import org.slf4j.{Logger, LoggerFactory}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.util.{Failure, Success, Try}
 
@@ -87,10 +88,91 @@ abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
       )
   }
 
-  private[this] def initialState(entityId: String): StateWrapper =
+  private[lagompb] def initialState(entityId: String): StateWrapper =
     StateWrapper()
       .withState(Any.pack(stateCompanion.defaultInstance))
       .withMeta(MetaData.defaultInstance.withEntityId(entityId))
+
+  /**
+   * Encrypt the event to persist whenever an encryption is set.
+   *
+   * @param event the event to persist
+   * @param state the resulting state
+   * @param metaData the additional meta
+   */
+  private[lagompb] def encryptEvent(event: Any, state: S, metaData: MetaData): (Any, Any, StateWrapper) = {
+    val encryptedEvent: Any = encryptionAdapter.encryptOrThrow(event)
+
+    // compute the resulting state once and reuse it
+    val anyResultingState: Any = Any.pack(state)
+
+    val encryptedResultingState: Any = encryptionAdapter.encryptOrThrow(anyResultingState)
+
+    (encryptedEvent,
+     encryptedResultingState,
+     StateWrapper()
+       .withState(anyResultingState)
+       .withMeta(metaData)
+    )
+  }
+
+  /**
+   * Call safely the event handler and return the resulting state when successful
+   *
+   * @param event the event to handle
+   * @param comp the companion object of the event to handle
+   * @param state the priorState to the event to handle
+   * @param metaData the additional meta
+   * @param replyTo the actor ref to reply to
+   */
+  private[lagompb] def persistEvent(event: Any,
+                                    comp: GeneratedMessageCompanion[_ <: GeneratedMessage],
+                                    state: S,
+                                    metaData: MetaData,
+                                    replyTo: ActorRef[CommandReply]
+  ): ReplyEffect[EventWrapper, StateWrapper] = {
+    Try {
+      eventHandler.handle(event.unpack(comp), state, metaData)
+    } match {
+      case Failure(exception) =>
+        log.error(s"event handler breakdown, ${exception.getMessage}", exception)
+
+        Effect.reply(replyTo)(
+          CommandReply()
+            .withFailedReply(
+              FailedReply()
+                .withReason(
+                  exception.getMessage
+                )
+                .withCause(FailureCause.ValidationError)
+            )
+        )
+
+      case Success(resultingState) =>
+        log.debug(
+          s"[Lagompb] user event handler returned ${resultingState.companion.scalaDescriptor.fullName}"
+        )
+
+        val (encryptedEvent, encryptedResultingState, decryptedStateWrapper) =
+          encryptEvent(event, resultingState, metaData)
+
+        Effect
+          .persist(
+            EventWrapper()
+              .withEvent(encryptedEvent)
+              .withResultingState(encryptedResultingState)
+              .withMeta(metaData)
+          )
+          .thenReply(replyTo) { (_: StateWrapper) =>
+            CommandReply()
+              .withSuccessfulReply(
+                SuccessfulReply()
+                  // return decrypted state, not persisted (encrypted) state
+                  .withStateWrapper(decryptedStateWrapper)
+              )
+          }
+    }
+  }
 
   /**
    * unpacks the nested state in the event, throws away prior state
@@ -182,37 +264,7 @@ abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
                           // the priorState will always have the entityId set in its meta even for the initial state
                           .withEntityId(stateWrapper.getMeta.entityId)
 
-                        // let us the event handler
-                        val resultingState: S = eventHandler
-                          .handle(event.unpack(comp), decryptedState, eventMeta)
-
-                        log.debug(
-                          s"[Lagompb] user event handler returned ${resultingState.companion.scalaDescriptor.fullName}"
-                        )
-
-                        val encryptedEvent: Any = encryptionAdapter.encryptOrThrow(event)
-                        val anyResultingState: Any = Any.pack(resultingState)
-                        val encryptedResultingState: Any = encryptionAdapter.encryptOrThrow(anyResultingState)
-
-                        val decryptedStateWrapper = StateWrapper()
-                          .withState(anyResultingState)
-                          .withMeta(eventMeta)
-
-                        Effect
-                          .persist(
-                            EventWrapper()
-                              .withEvent(encryptedEvent)
-                              .withResultingState(encryptedResultingState)
-                              .withMeta(eventMeta)
-                          )
-                          .thenReply(cmd.replyTo) { (_: StateWrapper) =>
-                            CommandReply()
-                              .withSuccessfulReply(
-                                SuccessfulReply()
-                                  // return decrypted state, not persisted (encrypted) state
-                                  .withStateWrapper(decryptedStateWrapper)
-                              )
-                          }
+                        persistEvent(event, comp, decryptedState, eventMeta, cmd.replyTo)
                     }
 
                   // the command handler return some unhandled successful response

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/AggregateRootSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/AggregateRootSpec.scala
@@ -342,5 +342,38 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
       )
     }
 
+    "handle event handler failure" in {
+      // Let us create the sender of commands
+      val commandSender: TestProbe[CommandReply] =
+        createTestProbe[CommandReply]()
+
+      val aggregate =
+        new TestAggregateRoot(
+          actorSystem,
+          new TestCommandHandler(actorSystem),
+          new TestEventHandler(actorSystem),
+          new EncryptionAdapter(encryptor = None)
+        )
+
+      // Let us create the aggregate
+      val aggregateId: String = randomId()
+      val aggregateRef: ActorRef[Command] =
+        spawn(aggregate.create(PersistenceId("TestAggregate", aggregateId)))
+      val testCmd = TestEventFailureCmd(companyUUID)
+
+      // let us send the command to the aggregate
+      aggregateRef ! Command(testCmd, commandSender.ref, Map.empty)
+      commandSender.receiveMessage(replyTimeout) match {
+        case CommandReply(reply) =>
+          reply match {
+            case Reply.FailedReply(value) =>
+              value.reason should include("an implementation is missing")
+              value.cause should ===(FailureCause.ValidationError)
+            case _ => fail("unexpected message type")
+          }
+        case _ => fail("unexpected message type")
+      }
+    }
+
   }
 }

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/AggregateRootSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/AggregateRootSpec.scala
@@ -368,7 +368,7 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
           reply match {
             case Reply.FailedReply(value) =>
               value.reason should include("an implementation is missing")
-              value.cause should ===(FailureCause.ValidationError)
+              value.cause should ===(FailureCause.InternalError)
             case _ => fail("unexpected message type")
           }
         case _ => fail("unexpected message type")

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestCommandHandler.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestCommandHandler.scala
@@ -17,8 +17,9 @@ class TestCommandHandler(actorSystem: ActorSystem) extends CommandHandler[TestSt
     currentEventMeta: MetaData
   ): Try[CommandHandlerResponse] =
     command.command match {
-      case cmd: TestCmd    => handleTestCmd(cmd, currentState)
-      case cmd: TestGetCmd => handleTestGetCmd(cmd, currentState)
+      case cmd: TestCmd             => handleTestCmd(cmd, currentState)
+      case cmd: TestGetCmd          => handleTestGetCmd(cmd, currentState)
+      case cmd: TestEventFailureCmd => handleTestEventHandlerFailure(cmd, currentState)
       case _: TestEmptyCmd =>
         Try(
           CommandHandlerResponse()
@@ -44,6 +45,16 @@ class TestCommandHandler(actorSystem: ActorSystem) extends CommandHandler[TestSt
       case _: TestFailCmd => throw new RuntimeException("I am failing...")
       case _              => handleInvalidCommand()
     }
+
+  def handleTestEventHandlerFailure(cmd: TestEventFailureCmd, currentState: TestState): Try[CommandHandlerResponse] = {
+    Try(
+      CommandHandlerResponse()
+        .withSuccessResponse(
+          SuccessCommandHandlerResponse()
+            .withEvent(Any.pack(TestEventFailure.defaultInstance))
+        )
+    )
+  }
 
   def handleTestGetCmd(cmd: TestGetCmd, currentState: TestState): Try[CommandHandlerResponse] =
     Try(

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestEventHandler.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestEventHandler.scala
@@ -3,7 +3,7 @@ package io.superflat.lagompb.data
 import akka.actor.ActorSystem
 import io.superflat.lagompb.EventHandler
 import io.superflat.lagompb.protobuf.core.MetaData
-import io.superflat.lagompb.protobuf.tests.{TestEvent, TestState}
+import io.superflat.lagompb.protobuf.tests.{TestEvent, TestEventFailure, TestState}
 
 class TestEventHandler(actorSystem: ActorSystem) extends EventHandler[TestState](actorSystem) {
 
@@ -11,7 +11,8 @@ class TestEventHandler(actorSystem: ActorSystem) extends EventHandler[TestState]
     event match {
       case TestEvent(companyUuid, name) =>
         handleTestEvent(companyUuid, name, currentState)
-      case _ => throw new NotImplementedError()
+      case TestEventFailure() => throw new NotImplementedError()
+      case _                  => throw new NotImplementedError()
     }
 
   private[this] def handleTestEvent(companyUuid: String, name: String, state: TestState): TestState =


### PR DESCRIPTION
With this PR anytime the event handler blows up the exception is properly handled which will avoid the actor system to kick start its failsafe mechanism by stopping the entity and throwing a generic exception.

Issue #141 