### PR TITLE
Issue 163: separate base command/event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ project/metals.sbt
 .DS_Store
 *.iml
 .protogen/
+.vscode/

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -139,7 +139,7 @@ abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
             .withFailedReply(
               FailedReply()
                 .withReason(
-                  s"[Lagompb] SimpleEventHandler failure: ${exception.getMessage}"
+                  s"[Lagompb] EventHandler failure: ${exception.getMessage}"
                 )
                 .withCause(FailureCause.INTERNAL_ERROR)
             )

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -209,7 +209,7 @@ abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
       case Success(decryptedState) =>
         log.debug(s"[Lagompb] plugin data ${cmd.data} is valid...")
 
-        commandHandler.handle(cmd, decryptedState, stateWrapper.getMeta) match {
+        commandHandler.handle(cmd.command, decryptedState, stateWrapper.getMeta) match {
 
           case Success(commandHandlerResponse: CommandHandlerResponse) =>
             commandHandlerResponse.handlerResponse match {

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -34,8 +34,8 @@ import scala.util.{Failure, Success, Try}
  */
 abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
   actorSystem: ActorSystem,
-  commandHandler: SimpleCommandHandler[S],
-  eventHandler: SimpleEventHandler[S],
+  commandHandler: CommandHandler,
+  eventHandler: EventHandler,
   encryptionAdapter: EncryptionAdapter
 ) {
 

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -17,7 +17,6 @@ import io.superflat.lagompb.protobuf.v1.core.CommandHandlerResponse.HandlerRespo
 }
 import io.superflat.lagompb.protobuf.v1.core.SuccessCommandHandlerResponse.Response.{Event, NoEvent}
 import org.slf4j.{Logger, LoggerFactory}
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.util.{Failure, Success, Try}
 
@@ -78,7 +77,7 @@ abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
     persistenceId: PersistenceId
   ): EventSourcedBehavior[Command, EventWrapper, StateWrapper] = {
     val splitter: Char = PersistenceId.DefaultSeparator(0)
-    val entityId = persistenceId.id.split(splitter).lastOption.getOrElse("")
+    val entityId: String = persistenceId.id.split(splitter).lastOption.getOrElse("")
     EventSourcedBehavior
       .withEnforcedReplies[Command, EventWrapper, StateWrapper](
         persistenceId = persistenceId,
@@ -117,8 +116,7 @@ abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
   /**
    * Call safely the event handler and return the resulting state when successful
    *
-   * @param event the event to handle
-   * @param comp the companion object of the event to handle
+   * @param event the event to handlecompanion object of the event to handle
    * @param state the priorState to the event to handle
    * @param metaData the additional meta
    * @param replyTo the actor ref to reply to
@@ -147,7 +145,7 @@ abstract class AggregateRoot[S <: scalapb.GeneratedMessage](
 
       case Success(resultingState) =>
         log.debug(
-          s"[Lagompb] user event handler returned ${resultingState.companion.scalaDescriptor.fullName}"
+          s"[Lagompb] user event handler returned ${resultingState.typeUrl}"
         )
 
         val (encryptedEvent, encryptedResultingState, decryptedStateWrapper) =

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/ApiSerializer.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/ApiSerializer.scala
@@ -22,19 +22,14 @@ case class ApiSerializer[A <: GeneratedMessage: GeneratedMessageCompanion]()
     acceptedMessageProtocols: Seq[MessageProtocol]
   ): MessageSerializer.NegotiatedSerializer[A, ByteString] =
     negotiateResponse(acceptedMessageProtocols)
-
-  // FIXME: find a better way to inject this or rewrite the api serializer and inject it via DI
-  override def protosRegistry: ProtosRegistry = ProtosRegistry.fromReflection()
 }
 
 sealed trait GenericSerializers[T <: GeneratedMessage] {
 
-  def protosRegistry: ProtosRegistry
-
   def deserializer(implicit T: GeneratedMessageCompanion[T]): NegotiatedDeserializer[T, ByteString] = {
     (wire: ByteString) =>
       {
-        protosRegistry.parser.fromJsonString(wire.utf8String)
+        ProtosRegistry.parser.fromJsonString(wire.utf8String)
       }
   }
 
@@ -58,7 +53,7 @@ sealed trait GenericSerializers[T <: GeneratedMessage] {
         MessageProtocol(Some("application/json"))
 
       override def serialize(message: T): ByteString =
-        ByteString(protosRegistry.printer.print(message))
+        ByteString(ProtosRegistry.printer.print(message))
     }
 
   def serializerProtobuf: NegotiatedSerializer[T, ByteString] =

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseApplication.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseApplication.scala
@@ -47,7 +47,7 @@ abstract class BaseApplication(context: LagomApplicationContext)
     Kamon.init()
   }
 
-  loadProtosRegistry()
+  val protosRegistry: ProtosRegistry = ProtosRegistry.fromReflection()
 
   // Json Serializer registry not needed
   final override lazy val jsonSerializerRegistry: JsonSerializerRegistry =
@@ -97,11 +97,6 @@ abstract class BaseApplication(context: LagomApplicationContext)
       selectShard(ConfigReader.eventsConfig.numShards, entityContext.entityId)
     aggregateRoot.create(entityContext, shardIndex)
   })
-
-  def loadProtosRegistry(): Unit = {
-    ProtosRegistry.registry
-    ProtosRegistry.typeRegistry
-  }
 
   // $COVERAGE-ON$
 }

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseApplication.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseApplication.scala
@@ -47,7 +47,7 @@ abstract class BaseApplication(context: LagomApplicationContext)
     Kamon.init()
   }
 
-  val protosRegistry: ProtosRegistry = ProtosRegistry.fromReflection()
+  ProtosRegistry.load()
 
   // Json Serializer registry not needed
   final override lazy val jsonSerializerRegistry: JsonSerializerRegistry =

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseService.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseService.scala
@@ -11,8 +11,10 @@ trait BaseService extends Service {
   protected val serviceName: String =
     ConfigReader.serviceName
 
+  def protosRegistry: ProtosRegistry
+
   implicit def messageSerializer[A <: GeneratedMessage: GeneratedMessageCompanion]: ApiSerializer[A] =
-    new ApiSerializer[A]
+    new ApiSerializer[A](protosRegistry)
 
   final override def descriptor: Descriptor = {
     import Service._

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseService.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseService.scala
@@ -11,10 +11,7 @@ trait BaseService extends Service {
   protected val serviceName: String =
     ConfigReader.serviceName
 
-  def protosRegistry: ProtosRegistry
-
-  implicit def messageSerializer[A <: GeneratedMessage: GeneratedMessageCompanion]: ApiSerializer[A] =
-    new ApiSerializer[A](protosRegistry)
+  implicit def messageSerializer[A <: GeneratedMessage: GeneratedMessageCompanion]: ApiSerializer[A] = ApiSerializer[A]
 
   final override def descriptor: Descriptor = {
     import Service._
@@ -23,7 +20,9 @@ trait BaseService extends Service {
       .foldLeft(
         named(serviceName)
           .withAutoAcl(true)
-      ) { _.addCalls(_) }
+      ) {
+        _.addCalls(_)
+      }
 
   }
 

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
@@ -112,10 +112,11 @@ sealed trait SharedBaseServiceImpl {
 abstract class BaseServiceImpl(
   val clusterSharding: ClusterSharding,
   val persistentEntityRegistry: PersistentEntityRegistry,
-  val aggregate: AggregateRoot[_]
+  val aggregate: AggregateRoot[_],
+  val protosRegistry: ProtosRegistry
 )(implicit ec: ExecutionContext)
-    extends SharedBaseServiceImpl
-    with BaseService {
+    extends BaseService
+    with SharedBaseServiceImpl {
 
   final val log: Logger = LoggerFactory.getLogger(getClass)
 

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
@@ -112,8 +112,7 @@ sealed trait SharedBaseServiceImpl {
 abstract class BaseServiceImpl(
   val clusterSharding: ClusterSharding,
   val persistentEntityRegistry: PersistentEntityRegistry,
-  val aggregate: AggregateRoot[_],
-  val protosRegistry: ProtosRegistry
+  val aggregate: AggregateRoot[_]
 )(implicit ec: ExecutionContext)
     extends BaseService
     with SharedBaseServiceImpl {

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
@@ -52,11 +52,12 @@ sealed trait SharedBaseServiceImpl {
     entityId: String,
     cmd: C,
     data: Map[String, String]
-  )(implicit ec: ExecutionContext): Future[StateAndMeta[S]] =
+  )(implicit ec: ExecutionContext): Future[StateAndMeta[S]] = {
     clusterSharding
       .entityRefFor(aggregateRoot.typeKey, entityId)
-      .ask[CommandReply](replyTo => Command(cmd, replyTo, data))
+      .ask[CommandReply](replyTo => Command(Any.pack(cmd), replyTo, data))
       .flatMap((value: CommandReply) => Future.fromTry(handleLagompbCommandReply[S](value)))
+  }
 
   private[lagompb] def handleLagompbCommandReply[S <: scalapb.GeneratedMessage](
     commandReply: CommandReply

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/Command.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/Command.scala
@@ -13,4 +13,7 @@ import io.superflat.lagompb.protobuf.v1.core.CommandReply
  *                    the plugin architecture is in placed
  * The CommandReply message type will be sent back that actor reference
  */
-final case class Command(command: scalapb.GeneratedMessage, replyTo: ActorRef[CommandReply], data: Map[String, String])
+final case class Command(command: com.google.protobuf.any.Any,
+                         replyTo: ActorRef[CommandReply],
+                         data: Map[String, String]
+)

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/Command.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/Command.scala
@@ -14,7 +14,4 @@ import io.superflat.lagompb.protobuf.v1.core.CommandReply
  *                    the plugin architecture is in placed
  * The CommandReply message type will be sent back that actor reference
  */
-final case class Command(command: Any,
-                         replyTo: ActorRef[CommandReply],
-                         data: Map[String, String]
-)
+final case class Command(command: Any, replyTo: ActorRef[CommandReply], data: Map[String, String])

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/Command.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/Command.scala
@@ -1,6 +1,7 @@
 package io.superflat.lagompb
 
 import akka.actor.typed.ActorRef
+import com.google.protobuf.any.Any
 import io.superflat.lagompb.protobuf.v1.core.CommandReply
 
 /**
@@ -13,7 +14,7 @@ import io.superflat.lagompb.protobuf.v1.core.CommandReply
  *                    the plugin architecture is in placed
  * The CommandReply message type will be sent back that actor reference
  */
-final case class Command(command: com.google.protobuf.any.Any,
+final case class Command(command: Any,
                          replyTo: ActorRef[CommandReply],
                          data: Map[String, String]
 )

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/CommandSerializer.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/CommandSerializer.scala
@@ -6,7 +6,6 @@ import akka.actor.ExtendedActorSystem
 import akka.actor.typed.{ActorRef, ActorRefResolver}
 import akka.actor.typed.scaladsl.adapter._
 import akka.serialization.SerializerWithStringManifest
-import com.google.protobuf.any.Any
 import io.superflat.lagompb.protobuf.v1.core.{CommandReply, CommandWrapper}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -21,7 +20,7 @@ sealed class CommandSerializer(val system: ExtendedActorSystem) extends Serializ
   final val log: Logger =
     LoggerFactory.getLogger(classOf[CommandSerializer])
 
-  private val actorRefResolver = ActorRefResolver(system.toTyped)
+  private val actorRefResolver: ActorRefResolver = ActorRefResolver(system.toTyped)
 
   override def manifest(o: AnyRef): String = o.getClass.getName
 
@@ -32,7 +31,7 @@ sealed class CommandSerializer(val system: ExtendedActorSystem) extends Serializ
           .toSerializationFormat(actorRef)
           .getBytes(StandardCharsets.UTF_8)
 
-        log.debug(s"serializing Command [${cmd.companion.scalaDescriptor.fullName}]")
+        log.debug(s"serializing Command [${cmd.companion.typeUrl}]")
 
         CommandWrapper()
           .withCommand(cmd)

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/CommandSerializer.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/CommandSerializer.scala
@@ -31,7 +31,7 @@ sealed class CommandSerializer(val system: ExtendedActorSystem) extends Serializ
           .toSerializationFormat(actorRef)
           .getBytes(StandardCharsets.UTF_8)
 
-        log.debug(s"serializing Command [${cmd.companion.typeUrl}]")
+        log.debug(s"serializing Command [${cmd.typeUrl}]")
 
         CommandWrapper()
           .withCommand(cmd)

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/Handlers.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/Handlers.scala
@@ -1,9 +1,21 @@
 package io.superflat.lagompb
 
 import akka.actor.ActorSystem
+import com.google.protobuf.any.Any
 import io.superflat.lagompb.protobuf.v1.core.{CommandHandlerResponse, MetaData}
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
+
+trait CommandHandler {
+  // TODO: make the command here an Any
+  // accomplish by making the command serializer pass around an Any first class,
+  // which eliminates the need for the proto registry in that serializer!
+  def handle(command: Command, currentState: Any, currentMetaData: MetaData): Try[CommandHandlerResponse]
+}
+
+trait EventHandler {
+  def handle(event: Any, currentState: Any, metaData: MetaData): Any
+}
 
 /**
  * LagompbCommandHandler
@@ -11,7 +23,20 @@ import scala.util.Try
  * @param actorSystem the actor system
  * @tparam S the aggregate state type
  */
-abstract class CommandHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem) {
+abstract class SimpleCommandHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem,
+                                                                   protosRegistry: ProtosRegistry
+) extends CommandHandler {
+
+  final def handle(command: Command, currentState: Any, currentMetaData: MetaData): Try[CommandHandlerResponse] = {
+    protosRegistry.unpackAny(currentState) match {
+      case Failure(exception) =>
+        throw exception
+
+      case Success(message) =>
+        val stateUnpacked: S = message.asInstanceOf[S]
+        handleTyped(command = command, currentState = stateUnpacked, currentMetaData = currentMetaData)
+    }
+  }
 
   /**
    * Handles a given command send to the entity
@@ -21,7 +46,7 @@ abstract class CommandHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorS
    * @param currentMetaData the current event meta before the command was triggered
    * @return CommandHandlerResponse
    */
-  def handle(command: Command, currentState: S, currentMetaData: MetaData): Try[CommandHandlerResponse]
+  def handleTyped(command: Command, currentState: S, currentMetaData: MetaData): Try[CommandHandlerResponse]
 }
 
 /**
@@ -30,7 +55,29 @@ abstract class CommandHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorS
  * @param actorSystem the actor system
  * @tparam S the aggregate state type
  */
-abstract class EventHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem) {
+abstract class SimpleEventHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem,
+                                                                 protosRegistry: ProtosRegistry
+) extends EventHandler {
+
+  /**
+   * uses protosRegistry to unmarshal proto messages and invoke implemented handleTyped
+   *
+   * @param event an Any message with an event
+   * @param currentState an Any message with current state
+   * @param metaData lagomPb MetaData
+   * @return an Any message with a resulting state
+   */
+  final def handle(event: Any, currentState: Any, metaData: MetaData): Any = {
+    protosRegistry.unpackAnys(currentState, event) match {
+      case Failure(exception) =>
+        throw exception
+
+      case Success(messages) =>
+        val stateUnpacked: S = messages(0).asInstanceOf[S]
+        val eventUnpacked = messages(1)
+        Any.pack(handleTyped(eventUnpacked, stateUnpacked, metaData))
+    }
+  }
 
   /**
    * Handles a given event ad return the resulting state
@@ -40,5 +87,5 @@ abstract class EventHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSys
    * @param metaData the event meta characterising the actual event.
    * @return the resulting state
    */
-  def handle(event: scalapb.GeneratedMessage, currentState: S, metaData: MetaData): S
+  def handleTyped(event: scalapb.GeneratedMessage, currentState: S, metaData: MetaData): S
 }

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/Handlers.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/Handlers.scala
@@ -28,12 +28,10 @@ trait EventHandler {
  * @param actorSystem the actor system
  * @tparam S the aggregate state type
  */
-abstract class TypedCommandHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem,
-                                                                  protosRegistry: ProtosRegistry
-) extends CommandHandler {
+abstract class TypedCommandHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem) extends CommandHandler {
 
   final def handle(command: Any, currentState: Any, currentMetaData: MetaData): Try[CommandHandlerResponse] = {
-    protosRegistry.unpackAnys(currentState, command) match {
+    ProtosRegistry.unpackAnys(currentState, command) match {
       case Failure(exception) =>
         Failure(exception)
 
@@ -68,9 +66,7 @@ abstract class TypedCommandHandler[S <: scalapb.GeneratedMessage](actorSystem: A
  * @param actorSystem the actor system
  * @tparam S the aggregate state type
  */
-abstract class TypedEventHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem,
-                                                                protosRegistry: ProtosRegistry
-) extends EventHandler {
+abstract class TypedEventHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem) extends EventHandler {
 
   /**
    * uses protosRegistry to unmarshal proto messages and invoke implemented handleTyped
@@ -81,7 +77,7 @@ abstract class TypedEventHandler[S <: scalapb.GeneratedMessage](actorSystem: Act
    * @return an Any message with a resulting state
    */
   final def handle(event: Any, currentState: Any, metaData: MetaData): Any = {
-    protosRegistry.unpackAnys(currentState, event) match {
+    ProtosRegistry.unpackAnys(currentState, event) match {
       case Failure(exception) =>
         throw exception
 

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/Handlers.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/Handlers.scala
@@ -10,6 +10,15 @@ import scala.util.{Failure, Success, Try}
  * CommandHandler is a generic command handler
  */
 trait CommandHandler {
+
+  /**
+   * generic method signature for handling commands
+   *
+   * @param command an Any message with a command inside
+   * @param currentState an Any message with a State inside
+   * @param currentMetaData lagom-pb meta data
+   * @return a command handler response or Failure
+   */
   def handle(command: Any, currentState: Any, currentMetaData: MetaData): Try[CommandHandlerResponse]
 }
 
@@ -17,6 +26,15 @@ trait CommandHandler {
  * EventHandler is a generic event handler
  */
 trait EventHandler {
+
+  /**
+   * generic method signature for handling events
+   *
+   * @param event an Any message with an event inside
+   * @param currentState an Any message with a State inside
+   * @param metaData lagom-pb meta data
+   * @return an Any message with the resulting state
+   */
   def handle(event: Any, currentState: Any, metaData: MetaData): Any
 }
 
@@ -30,6 +48,15 @@ trait EventHandler {
  */
 abstract class TypedCommandHandler[S <: scalapb.GeneratedMessage](actorSystem: ActorSystem) extends CommandHandler {
 
+  /**
+   * implements CommandHandler.handle and uses proto registry to unmarshal
+   * proto messages and invoke implemented handleTyped
+   *
+   * @param command an Any message with a command
+   * @param currentState an Any message with current state
+   * @param metaData lagomPb MetaData
+   * @return a command handler response or Failure
+   */
   final def handle(command: Any, currentState: Any, currentMetaData: MetaData): Try[CommandHandlerResponse] = {
     ProtosRegistry.unpackAnys(currentState, command) match {
       case Failure(exception) =>

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/Handlers.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/Handlers.scala
@@ -44,7 +44,10 @@ abstract class SimpleCommandHandler[S <: scalapb.GeneratedMessage](actorSystem: 
    * @param currentMetaData the current event meta before the command was triggered
    * @return CommandHandlerResponse
    */
-  def handleTyped(command: scalapb.GeneratedMessage, currentState: S, currentMetaData: MetaData): Try[CommandHandlerResponse]
+  def handleTyped(command: scalapb.GeneratedMessage,
+                  currentState: S,
+                  currentMetaData: MetaData
+  ): Try[CommandHandlerResponse]
 }
 
 /**

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/ProtosRegistry.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/ProtosRegistry.scala
@@ -56,7 +56,7 @@ class ProtosRegistry(private[lagompb] val registry: Seq[GeneratedFileObject]) {
    * @return the maybe scalapb GeneratedMessageCompanion object
    */
   def getCompanion(any: Any): Option[GeneratedMessageCompanion[_ <: GeneratedMessage]] =
-    companionsMap.get(any.typeUrl.split('/').lastOption.getOrElse(""))
+    any.typeUrl.split('/').lastOption.flatMap(companionsMap.get)
 
   /**
    * Unpack a proto Any into its scalapb class, or fail

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/ProtosRegistry.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/ProtosRegistry.scala
@@ -6,10 +6,10 @@ import org.slf4j.{Logger, LoggerFactory}
 import scalapb.{GeneratedFileObject, GeneratedMessage, GeneratedMessageCompanion}
 import scalapb.json4s.{Parser, Printer, TypeRegistry}
 
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe
 import scala.util.{Failure, Success, Try}
-import scala.collection.mutable
 
 /**
  * Helpful registry of scalapb protobuf classes that can be used to find
@@ -143,7 +143,7 @@ object ProtosRegistry {
    * @return instantiated ProtosRegistry
    */
   def fromReflection(): ProtosRegistry = {
-    val registry = load()
+    val registry: Seq[GeneratedFileObject] = load()
     new ProtosRegistry(registry)
   }
 }

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/AggregateRootSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/AggregateRootSpec.scala
@@ -40,7 +40,6 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
   }
 
   val actorSystem: ActorSystem = testKit.system.toClassic
-  val protosRegistry: ProtosRegistry = ProtosRegistry.fromReflection()
 
   "Aggregate Implementation" should {
 
@@ -52,8 +51,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
       val aggregate =
         new TestAggregateRoot(
           actorSystem,
-          new TestCommandHandler(actorSystem, protosRegistry),
-          new TestEventHandler(actorSystem, protosRegistry),
+          new TestCommandHandler(actorSystem),
+          new TestEventHandler(actorSystem),
           new EncryptionAdapter(encryptor = None)
         )
 
@@ -89,8 +88,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
 
       val aggregate =
         new TestAggregateRoot(actorSystem,
-                              new TestCommandHandler(actorSystem, protosRegistry),
-                              new TestEventHandler(actorSystem, protosRegistry),
+                              new TestCommandHandler(actorSystem),
+                              new TestEventHandler(actorSystem),
                               new EncryptionAdapter(None)
         )
 
@@ -122,8 +121,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
       val aggregate =
         new TestAggregateRoot(
           actorSystem,
-          new TestCommandHandler(actorSystem, protosRegistry),
-          new TestEventHandler(actorSystem, protosRegistry),
+          new TestCommandHandler(actorSystem),
+          new TestEventHandler(actorSystem),
           new EncryptionAdapter(None)
         )
 
@@ -159,8 +158,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
 
       val aggregate =
         new TestAggregateRoot(actorSystem,
-                              new TestCommandHandler(actorSystem, protosRegistry),
-                              new TestEventHandler(actorSystem, protosRegistry),
+                              new TestCommandHandler(actorSystem),
+                              new TestEventHandler(actorSystem),
                               new EncryptionAdapter(None)
         )
 
@@ -191,8 +190,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
       val aggregate =
         new TestAggregateRoot(
           actorSystem,
-          new TestCommandHandler(actorSystem, protosRegistry),
-          new TestEventHandler(actorSystem, protosRegistry),
+          new TestCommandHandler(actorSystem),
+          new TestEventHandler(actorSystem),
           new EncryptionAdapter(None)
         )
 
@@ -223,8 +222,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
       val aggregate =
         new TestAggregateRoot(
           actorSystem,
-          new TestCommandHandler(actorSystem, protosRegistry),
-          new TestEventHandler(actorSystem, protosRegistry),
+          new TestCommandHandler(actorSystem),
+          new TestEventHandler(actorSystem),
           new EncryptionAdapter(None)
         )
 
@@ -255,8 +254,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
 
       val aggregate =
         new TestAggregateRoot(actorSystem,
-                              new TestCommandHandler(actorSystem, protosRegistry),
-                              new TestEventHandler(actorSystem, protosRegistry),
+                              new TestCommandHandler(actorSystem),
+                              new TestEventHandler(actorSystem),
                               new EncryptionAdapter(None)
         )
 
@@ -274,8 +273,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
     "handle wrong state parsing" in {
       val aggregate =
         new TestAggregateRoot(actorSystem,
-                              new TestCommandHandler(actorSystem, protosRegistry),
-                              new TestEventHandler(actorSystem, protosRegistry),
+                              new TestCommandHandler(actorSystem),
+                              new TestEventHandler(actorSystem),
                               new EncryptionAdapter(None)
         )
 
@@ -299,8 +298,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
       val companyUuid = "12234"
       val aggregate =
         new TestAggregateRoot(actorSystem,
-                              new TestCommandHandler(actorSystem, protosRegistry),
-                              new TestEventHandler(actorSystem, protosRegistry),
+                              new TestCommandHandler(actorSystem),
+                              new TestEventHandler(actorSystem),
                               new EncryptionAdapter(None)
         )
 
@@ -351,8 +350,8 @@ class AggregateRootSpec extends BaseActorTestKit(s"""
       val aggregate =
         new TestAggregateRoot(
           actorSystem,
-          new TestCommandHandler(actorSystem, protosRegistry),
-          new TestEventHandler(actorSystem, protosRegistry),
+          new TestCommandHandler(actorSystem),
+          new TestEventHandler(actorSystem),
           new EncryptionAdapter(encryptor = None)
         )
 

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/BaseServiceImplSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/BaseServiceImplSpec.scala
@@ -16,7 +16,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class BaseServiceImplSpec extends BaseSpec {
   val companyId: String = UUID.randomUUID().toString
-  val protosRegistry: ProtosRegistry = ProtosRegistry.fromReflection()
 
   val any: Any =
     Any.pack(
@@ -34,11 +33,11 @@ class BaseServiceImplSpec extends BaseSpec {
 
   "Service implementation" should {
     "parse proto Any and return a State" in {
-      val commandHandler = new TestCommandHandler(null, protosRegistry)
-      val eventHandler = new TestEventHandler(null, protosRegistry)
+      val commandHandler = new TestCommandHandler(null)
+      val eventHandler = new TestEventHandler(null)
       val aggregate =
         new TestAggregateRoot(null, commandHandler, eventHandler, defaultEncryptionAdapter)
-      val testImpl = new TestServiceImpl(null, null, null, aggregate, protosRegistry)
+      val testImpl = new TestServiceImpl(null, null, null, aggregate)
       testImpl.parseAny[TestState](any) shouldBe
         TestState()
           .withCompanyUuid(companyId)
@@ -46,11 +45,11 @@ class BaseServiceImplSpec extends BaseSpec {
     }
 
     "fail to handle wrong proto Any" in {
-      val commandHandler = new TestCommandHandler(null, protosRegistry)
-      val eventHandler = new TestEventHandler(null, protosRegistry)
+      val commandHandler = new TestCommandHandler(null)
+      val eventHandler = new TestEventHandler(null)
       val aggregate =
         new TestAggregateRoot(null, commandHandler, eventHandler, defaultEncryptionAdapter)
-      val testImpl = new TestServiceImpl(null, null, null, aggregate, protosRegistry)
+      val testImpl = new TestServiceImpl(null, null, null, aggregate)
       an[RuntimeException] shouldBe thrownBy(
         testImpl.parseAny[TestState](
           Any()
@@ -61,11 +60,11 @@ class BaseServiceImplSpec extends BaseSpec {
     }
 
     "handle SuccessfulReply" in {
-      val commandHandler = new TestCommandHandler(null, protosRegistry)
-      val eventHandler = new TestEventHandler(null, protosRegistry)
+      val commandHandler = new TestCommandHandler(null)
+      val eventHandler = new TestEventHandler(null)
       val aggregate =
         new TestAggregateRoot(null, commandHandler, eventHandler, defaultEncryptionAdapter)
-      val testImpl = new TestServiceImpl(null, null, null, aggregate, protosRegistry)
+      val testImpl = new TestServiceImpl(null, null, null, aggregate)
 
       val cmdReply = CommandReply()
         .withSuccessfulReply(
@@ -87,11 +86,11 @@ class BaseServiceImplSpec extends BaseSpec {
     }
 
     "handle FailedReply" in {
-      val commandHandler = new TestCommandHandler(null, protosRegistry)
-      val eventHandler = new TestEventHandler(null, protosRegistry)
+      val commandHandler = new TestCommandHandler(null)
+      val eventHandler = new TestEventHandler(null)
       val aggregate =
         new TestAggregateRoot(null, commandHandler, eventHandler, defaultEncryptionAdapter)
-      val testImpl = new TestServiceImpl(null, null, null, aggregate, protosRegistry)
+      val testImpl = new TestServiceImpl(null, null, null, aggregate)
       val rejected =
         CommandReply()
           .withFailedReply(
@@ -102,11 +101,11 @@ class BaseServiceImplSpec extends BaseSpec {
     }
 
     "failed to handle CommandReply" in {
-      val commandHandler = new TestCommandHandler(null, protosRegistry)
-      val eventHandler = new TestEventHandler(null, protosRegistry)
+      val commandHandler = new TestCommandHandler(null)
+      val eventHandler = new TestEventHandler(null)
       val aggregate =
         new TestAggregateRoot(null, commandHandler, eventHandler, defaultEncryptionAdapter)
-      val testImpl = new TestServiceImpl(null, null, null, aggregate, protosRegistry)
+      val testImpl = new TestServiceImpl(null, null, null, aggregate)
       case class WrongReply()
       testImpl
         .handleLagompbCommandReply[TestState](CommandReply().withReply(Reply.Empty))
@@ -115,11 +114,11 @@ class BaseServiceImplSpec extends BaseSpec {
     }
 
     "parse State" in {
-      val commandHandler = new TestCommandHandler(null, protosRegistry)
-      val eventHandler = new TestEventHandler(null, protosRegistry)
+      val commandHandler = new TestCommandHandler(null)
+      val eventHandler = new TestEventHandler(null)
       val aggregate =
         new TestAggregateRoot(null, commandHandler, eventHandler, defaultEncryptionAdapter)
-      val testImpl = new TestServiceImpl(null, null, null, aggregate, protosRegistry)
+      val testImpl = new TestServiceImpl(null, null, null, aggregate)
 
       testImpl
         .parseState[TestState](
@@ -134,11 +133,11 @@ class BaseServiceImplSpec extends BaseSpec {
     }
 
     "fail to parse state[No State provided]" in {
-      val commandHandler = new TestCommandHandler(null, protosRegistry)
-      val eventHandler = new TestEventHandler(null, protosRegistry)
+      val commandHandler = new TestCommandHandler(null)
+      val eventHandler = new TestEventHandler(null)
       val aggregate =
         new TestAggregateRoot(null, commandHandler, eventHandler, defaultEncryptionAdapter)
-      val testImpl = new TestServiceImpl(null, null, null, aggregate, protosRegistry)
+      val testImpl = new TestServiceImpl(null, null, null, aggregate)
       an[RuntimeException] shouldBe thrownBy(
         testImpl.parseState[TestState](
           StateWrapper()

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/CommandHandlerSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/CommandHandlerSpec.scala
@@ -18,9 +18,10 @@ class CommandHandlerSpec extends BaseActorTestKit(s"""
       akka.persistence.snapshot-store.local.dir = "tmp/snapshot"
     """) {
 
+  val protosRegistry = ProtosRegistry.fromReflection()
   val actorSystem: ActorSystem = testKit.system.toClassic
   val companyId: String = UUID.randomUUID().toString
-  val cmdHandler = new TestCommandHandler(actorSystem)
+  val cmdHandler = new TestCommandHandler(actorSystem, protosRegistry)
 
   "CommandHandler implementation" should {
     "handle valid command as expected" in {
@@ -57,7 +58,7 @@ class CommandHandlerSpec extends BaseActorTestKit(s"""
       val state = TestState(companyId, "state")
       val meta = MetaData(revisionNumber = 1)
       val result: Try[CommandHandlerResponse] =
-        cmdHandler.handle(Command(testCmd, null, Map.empty[String, String]), state, meta)
+        cmdHandler.handle(Any.pack(testCmd), Any.pack(state), meta)
 
       result.success.value shouldBe
         CommandHandlerResponse()
@@ -72,7 +73,7 @@ class CommandHandlerSpec extends BaseActorTestKit(s"""
       val state = TestState(UUID.randomUUID().toString, "state")
       val meta = MetaData(revisionNumber = 1)
       val result: Try[CommandHandlerResponse] =
-        cmdHandler.handle(Command(testCmd, null, Map.empty[String, String]), state, meta)
+        cmdHandler.handle(Any.pack(testCmd), Any.pack(state), meta)
 
       result.success.value shouldBe
         CommandHandlerResponse()
@@ -97,7 +98,7 @@ class CommandHandlerSpec extends BaseActorTestKit(s"""
       val noCmd = NoCmd()
       val meta = MetaData(revisionNumber = 1)
       cmdHandler
-        .handle(Command(noCmd, null, Map.empty[String, String]), TestState(companyId, "state"), meta)
+        .handle(Any.pack(noCmd), Any.pack(TestState(companyId, "state")), meta)
         .success
         .value shouldBe
         CommandHandlerResponse()

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/CommandHandlerSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/CommandHandlerSpec.scala
@@ -18,10 +18,9 @@ class CommandHandlerSpec extends BaseActorTestKit(s"""
       akka.persistence.snapshot-store.local.dir = "tmp/snapshot"
     """) {
 
-  val protosRegistry = ProtosRegistry.fromReflection()
   val actorSystem: ActorSystem = testKit.system.toClassic
   val companyId: String = UUID.randomUUID().toString
-  val cmdHandler = new TestCommandHandler(actorSystem, protosRegistry)
+  val cmdHandler = new TestCommandHandler(actorSystem)
 
   "CommandHandler implementation" should {
     "handle valid command as expected" in {

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/CommandSerializerSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/CommandSerializerSpec.scala
@@ -4,6 +4,7 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import io.superflat.lagompb.testkit.BaseActorTestKit
 import io.superflat.lagompb.protobuf.v1.core.CommandReply
 import io.superflat.lagompb.protobuf.v1.tests.TestCmd
+import com.google.protobuf.any.Any
 
 class CommandSerializerSpec extends BaseActorTestKit(s"""
     akka {
@@ -27,6 +28,6 @@ class CommandSerializerSpec extends BaseActorTestKit(s"""
     val command = TestCmd(companyUUID, "John Ross")
     val data =
       Map("audit|employeeUuid" -> "1223", "audit|createdAt" -> "2020-04-17")
-    serializationTestKit.verifySerialization(Command(command, probe.ref, data))
+    serializationTestKit.verifySerialization(Command(Any.pack(command), probe.ref, data))
   }
 }

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/EventHandlerSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/EventHandlerSpec.scala
@@ -8,6 +8,7 @@ import io.superflat.lagompb.data.TestEventHandler
 import io.superflat.lagompb.testkit.BaseActorTestKit
 import io.superflat.lagompb.protobuf.v1.core.MetaData
 import io.superflat.lagompb.protobuf.v1.tests.{TestEvent, TestState, WrongEvent}
+import com.google.protobuf.any.Any
 
 class EventHandlerSpec extends BaseActorTestKit(s"""
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
@@ -16,23 +17,26 @@ class EventHandlerSpec extends BaseActorTestKit(s"""
     """) {
 
   val actorSystem: ActorSystem = testKit.system.toClassic
+  val protosRegistry: ProtosRegistry = ProtosRegistry.fromReflection()
 
   "EventHandler implementation" must {
     val companyId: String = UUID.randomUUID().toString
-    val eventHandler = new TestEventHandler(actorSystem)
+    val eventHandler: TestEventHandler = new TestEventHandler(actorSystem, protosRegistry)
 
     "handle event and return the new state" in {
-      val prevState = TestState(companyId, "state")
-      val event = TestEvent(companyId, "new state")
+      val prevState: TestState = TestState(companyId, "state")
+      val event: TestEvent = TestEvent(companyId, "new state")
 
-      val result: TestState =
-        eventHandler.handle(event, prevState, MetaData.defaultInstance)
-      result should be(TestState(companyId, "new state"))
+      val result: Any =
+        eventHandler.handle(Any.pack(event), Any.pack(prevState), MetaData.defaultInstance)
+      result.unpack[TestState] should be(TestState(companyId, "new state"))
     }
 
     "handle wrong event" in {
-      val prevState = TestState(companyId, "state")
-      assertThrows[NotImplementedError](eventHandler.handle(WrongEvent(), prevState, MetaData.defaultInstance))
+      val prevState: TestState = TestState(companyId, "state")
+      assertThrows[NotImplementedError](
+        eventHandler.handle(Any.pack(WrongEvent()), Any.pack(prevState), MetaData.defaultInstance)
+      )
     }
   }
 }

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/EventHandlerSpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/EventHandlerSpec.scala
@@ -17,11 +17,10 @@ class EventHandlerSpec extends BaseActorTestKit(s"""
     """) {
 
   val actorSystem: ActorSystem = testKit.system.toClassic
-  val protosRegistry: ProtosRegistry = ProtosRegistry.fromReflection()
 
   "EventHandler implementation" must {
     val companyId: String = UUID.randomUUID().toString
-    val eventHandler: TestEventHandler = new TestEventHandler(actorSystem, protosRegistry)
+    val eventHandler: TestEventHandler = new TestEventHandler(actorSystem)
 
     "handle event and return the new state" in {
       val prevState: TestState = TestState(companyId, "state")

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/ProtosRegistrySpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/ProtosRegistrySpec.scala
@@ -11,27 +11,26 @@ class ProtosRegistrySpec extends BaseSpec {
 
   "Loading GeneratedFileObject" should {
 
-    val protosRegistry = ProtosRegistry.fromReflection()
     "succeed" in {
-      val fos = protosRegistry.registry
+      val fos = ProtosRegistry.registry
       fos.size should be >= 1
       fos should contain(CoreProto)
     }
 
     "should be loaded" in {
-      val size: Int = protosRegistry.companions.size
+      val size: Int = ProtosRegistry.companions.size
       size should be >= 1
     }
 
     "Contains the companions" in {
       val map: Map[String, GeneratedMessageCompanion[_ <: GeneratedMessage]] =
-        protosRegistry.companionsMap
+        ProtosRegistry.companionsMap
       map.keySet should contain("lagompb.v1.TestCmd")
     }
 
     "Gets scalapb GeneratedMessageCompanion object" in {
       val any = Any.pack(TestCmd.defaultInstance)
-      protosRegistry.getCompanion(any) should be(Symbol("defined"))
+      ProtosRegistry.getCompanion(any) should be(Symbol("defined"))
     }
   }
 }

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/ProtosRegistrySpec.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/ProtosRegistrySpec.scala
@@ -11,26 +11,27 @@ class ProtosRegistrySpec extends BaseSpec {
 
   "Loading GeneratedFileObject" should {
 
+    val protosRegistry = ProtosRegistry.fromReflection()
     "succeed" in {
-      val fos = ProtosRegistry.registry
+      val fos = protosRegistry.registry
       fos.size should be >= 1
       fos should contain(CoreProto)
     }
 
     "should be loaded" in {
-      val size: Int = ProtosRegistry.companions.size
+      val size: Int = protosRegistry.companions.size
       size should be >= 1
     }
 
     "Contains the companions" in {
       val map: Map[String, GeneratedMessageCompanion[_ <: GeneratedMessage]] =
-        ProtosRegistry.companionsMap
+        protosRegistry.companionsMap
       map.keySet should contain("lagompb.v1.TestCmd")
     }
 
     "Gets scalapb GeneratedMessageCompanion object" in {
       val any = Any.pack(TestCmd.defaultInstance)
-      ProtosRegistry.companion(any) should be(Symbol("defined"))
+      protosRegistry.getCompanion(any) should be(Symbol("defined"))
     }
   }
 }

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestAggregateRoot.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestAggregateRoot.scala
@@ -1,15 +1,15 @@
 package io.superflat.lagompb.data
 
 import akka.actor.ActorSystem
-import io.superflat.lagompb.{AggregateRoot, CommandHandler, EventHandler}
+import io.superflat.lagompb.{AggregateRoot, TypedCommandHandler, TypedEventHandler}
 import io.superflat.lagompb.encryption.EncryptionAdapter
 import io.superflat.lagompb.protobuf.v1.tests.TestState
 import scalapb.GeneratedMessageCompanion
 
 final class TestAggregateRoot(
   actorSystem: ActorSystem,
-  commandHandler: CommandHandler[TestState],
-  eventHandler: EventHandler[TestState],
+  commandHandler: TypedCommandHandler[TestState],
+  eventHandler: TypedEventHandler[TestState],
   encryptionAdapter: EncryptionAdapter
 ) extends AggregateRoot[TestState](actorSystem, commandHandler, eventHandler, encryptionAdapter) {
 

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestApplication.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestApplication.scala
@@ -2,14 +2,14 @@ package io.superflat.lagompb.data
 
 import com.lightbend.lagom.scaladsl.server.{LagomApplicationContext, LagomServer, LocalServiceLocator}
 import com.softwaremill.macwire.wire
-import io.superflat.lagompb.{AggregateRoot, BaseApplication, CommandHandler, EventHandler}
+import io.superflat.lagompb.{AggregateRoot, BaseApplication, TypedCommandHandler, TypedEventHandler}
 import io.superflat.lagompb.protobuf.v1.tests.TestState
 
 class TestApplication(context: LagomApplicationContext) extends BaseApplication(context) with LocalServiceLocator {
 
-  def eventHandler: EventHandler[TestState] = wire[TestEventHandler]
+  def eventHandler: TypedEventHandler[TestState] = wire[TestEventHandler]
 
-  def commandHandler: CommandHandler[TestState] = wire[TestCommandHandler]
+  def commandHandler: TypedCommandHandler[TestState] = wire[TestCommandHandler]
 
   def aggregate: AggregateRoot[TestState] = wire[TestAggregateRoot]
 

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestCommandHandler.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestCommandHandler.scala
@@ -2,15 +2,15 @@ package io.superflat.lagompb.data
 
 import akka.actor.ActorSystem
 import com.google.protobuf.any.Any
-import io.superflat.lagompb.{Command, SimpleCommandHandler}
 import io.superflat.lagompb.protobuf.v1.core._
 import io.superflat.lagompb.protobuf.v1.core.CommandHandlerResponse.HandlerResponse
 import io.superflat.lagompb.protobuf.v1.tests._
+import io.superflat.lagompb.{ProtosRegistry, TypedCommandHandler}
 
 import scala.util.Try
-import io.superflat.lagompb.ProtosRegistry
 
-class TestCommandHandler(actorSystem: ActorSystem, protosRegistry: ProtosRegistry) extends SimpleCommandHandler[TestState](actorSystem, protosRegistry) {
+class TestCommandHandler(actorSystem: ActorSystem, protosRegistry: ProtosRegistry)
+    extends TypedCommandHandler[TestState](actorSystem, protosRegistry) {
 
   override def handleTyped(
     command: scalapb.GeneratedMessage,

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestCommandHandler.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestCommandHandler.scala
@@ -9,8 +9,7 @@ import io.superflat.lagompb.{ProtosRegistry, TypedCommandHandler}
 
 import scala.util.Try
 
-class TestCommandHandler(actorSystem: ActorSystem, protosRegistry: ProtosRegistry)
-    extends TypedCommandHandler[TestState](actorSystem, protosRegistry) {
+class TestCommandHandler(actorSystem: ActorSystem) extends TypedCommandHandler[TestState](actorSystem) {
 
   override def handleTyped(
     command: scalapb.GeneratedMessage,

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestCommandHandler.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestCommandHandler.scala
@@ -2,21 +2,22 @@ package io.superflat.lagompb.data
 
 import akka.actor.ActorSystem
 import com.google.protobuf.any.Any
-import io.superflat.lagompb.{Command, CommandHandler}
+import io.superflat.lagompb.{Command, SimpleCommandHandler}
 import io.superflat.lagompb.protobuf.v1.core._
 import io.superflat.lagompb.protobuf.v1.core.CommandHandlerResponse.HandlerResponse
 import io.superflat.lagompb.protobuf.v1.tests._
 
 import scala.util.Try
+import io.superflat.lagompb.ProtosRegistry
 
-class TestCommandHandler(actorSystem: ActorSystem) extends CommandHandler[TestState](actorSystem) {
+class TestCommandHandler(actorSystem: ActorSystem, protosRegistry: ProtosRegistry) extends SimpleCommandHandler[TestState](actorSystem, protosRegistry) {
 
-  override def handle(
-    command: Command,
+  override def handleTyped(
+    command: scalapb.GeneratedMessage,
     currentState: TestState,
     currentEventMeta: MetaData
   ): Try[CommandHandlerResponse] =
-    command.command match {
+    command match {
       case cmd: TestCmd             => handleTestCmd(cmd, currentState)
       case cmd: TestGetCmd          => handleTestGetCmd(cmd, currentState)
       case cmd: TestEventFailureCmd => handleTestEventHandlerFailure(cmd, currentState)

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestEventHandler.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestEventHandler.scala
@@ -1,13 +1,14 @@
 package io.superflat.lagompb.data
 
 import akka.actor.ActorSystem
-import io.superflat.lagompb.EventHandler
+import io.superflat.lagompb.{ProtosRegistry, TypedEventHandler}
 import io.superflat.lagompb.protobuf.v1.core.MetaData
 import io.superflat.lagompb.protobuf.v1.tests.{TestEvent, TestEventFailure, TestState}
 
-class TestEventHandler(actorSystem: ActorSystem) extends EventHandler[TestState](actorSystem) {
+class TestEventHandler(actorSystem: ActorSystem, protosRegistry: ProtosRegistry)
+    extends TypedEventHandler[TestState](actorSystem, protosRegistry) {
 
-  override def handle(event: scalapb.GeneratedMessage, currentState: TestState, eventMeta: MetaData): TestState =
+  override def handleTyped(event: scalapb.GeneratedMessage, currentState: TestState, eventMeta: MetaData): TestState =
     event match {
       case TestEvent(companyUuid, name, _) =>
         handleTestEvent(companyUuid, name, currentState)

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestEventHandler.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestEventHandler.scala
@@ -5,8 +5,7 @@ import io.superflat.lagompb.{ProtosRegistry, TypedEventHandler}
 import io.superflat.lagompb.protobuf.v1.core.MetaData
 import io.superflat.lagompb.protobuf.v1.tests.{TestEvent, TestEventFailure, TestState}
 
-class TestEventHandler(actorSystem: ActorSystem, protosRegistry: ProtosRegistry)
-    extends TypedEventHandler[TestState](actorSystem, protosRegistry) {
+class TestEventHandler(actorSystem: ActorSystem) extends TypedEventHandler[TestState](actorSystem) {
 
   override def handleTyped(event: scalapb.GeneratedMessage, currentState: TestState, eventMeta: MetaData): TestState =
     event match {

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestService.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestService.scala
@@ -8,7 +8,7 @@ import com.lightbend.lagom.scaladsl.api.{Descriptor, ServiceCall}
 import com.lightbend.lagom.scaladsl.api.Service.restCall
 import com.lightbend.lagom.scaladsl.api.transport.Method
 import com.lightbend.lagom.scaladsl.persistence.PersistentEntityRegistry
-import io.superflat.lagompb.{AggregateRoot, BaseService, BaseServiceImpl, StateAndMeta}
+import io.superflat.lagompb.{AggregateRoot, BaseService, BaseServiceImpl, ProtosRegistry, StateAndMeta}
 import io.superflat.lagompb.protobuf.v1.tests.{TestCmd, TestState}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
@@ -29,9 +29,10 @@ class TestServiceImpl(
   sys: ActorSystem,
   clusterSharding: ClusterSharding,
   persistentEntityRegistry: PersistentEntityRegistry,
-  aggregate: AggregateRoot[TestState]
+  aggregate: AggregateRoot[TestState],
+  protosRegistry: ProtosRegistry
 )(implicit ec: ExecutionContext)
-    extends BaseServiceImpl(clusterSharding, persistentEntityRegistry, aggregate)
+    extends BaseServiceImpl(clusterSharding, persistentEntityRegistry, aggregate, protosRegistry)
     with TestService {
 
   /**

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestService.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestService.scala
@@ -29,10 +29,9 @@ class TestServiceImpl(
   sys: ActorSystem,
   clusterSharding: ClusterSharding,
   persistentEntityRegistry: PersistentEntityRegistry,
-  aggregate: AggregateRoot[TestState],
-  protosRegistry: ProtosRegistry
+  aggregate: AggregateRoot[TestState]
 )(implicit ec: ExecutionContext)
-    extends BaseServiceImpl(clusterSharding, persistentEntityRegistry, aggregate, protosRegistry)
+    extends BaseServiceImpl(clusterSharding, persistentEntityRegistry, aggregate)
     with TestService {
 
   /**

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/EventsReader.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/EventsReader.scala
@@ -19,11 +19,8 @@ import scala.util.{Failure, Success, Try}
  * @param eventProcessor the actual event processor
  * @param encryptionAdapter handles encrypt/decrypt transformations
  */
-final class EventsReader(eventTag: String,
-                         eventProcessor: EventProcessor,
-                         encryptionAdapter: EncryptionAdapter,
-                         protosRegistry: ProtosRegistry
-) extends SlickHandler[EventEnvelope[EventWrapper]] {
+final class EventsReader(eventTag: String, eventProcessor: EventProcessor, encryptionAdapter: EncryptionAdapter)
+    extends SlickHandler[EventEnvelope[EventWrapper]] {
 
   val log: Logger = LoggerFactory.getLogger(getClass)
 
@@ -39,7 +36,7 @@ final class EventsReader(eventTag: String,
       .decryptEventWrapper(envelope.event)
       .map({
         case EventWrapper(Some(event: any.Any), Some(resultingState), Some(meta), _) =>
-          protosRegistry.getCompanion(event) match {
+          ProtosRegistry.getCompanion(event) match {
             case Some(comp) =>
               eventProcessor
                 .process(comp, event, eventTag, resultingState, meta)

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/EventsReader.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/EventsReader.scala
@@ -19,8 +19,11 @@ import scala.util.{Failure, Success, Try}
  * @param eventProcessor the actual event processor
  * @param encryptionAdapter handles encrypt/decrypt transformations
  */
-final class EventsReader(eventTag: String, eventProcessor: EventProcessor, encryptionAdapter: EncryptionAdapter)
-    extends SlickHandler[EventEnvelope[EventWrapper]] {
+final class EventsReader(eventTag: String,
+                         eventProcessor: EventProcessor,
+                         encryptionAdapter: EncryptionAdapter,
+                         protosRegistry: ProtosRegistry
+) extends SlickHandler[EventEnvelope[EventWrapper]] {
 
   val log: Logger = LoggerFactory.getLogger(getClass)
 
@@ -36,7 +39,7 @@ final class EventsReader(eventTag: String, eventProcessor: EventProcessor, encry
       .decryptEventWrapper(envelope.event)
       .map({
         case EventWrapper(Some(event: any.Any), Some(resultingState), Some(meta), _) =>
-          ProtosRegistry.companion(event) match {
+          protosRegistry.getCompanion(event) match {
             case Some(comp) =>
               eventProcessor
                 .process(comp, event, eventTag, resultingState, meta)

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/KafkaPublisher.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/KafkaPublisher.scala
@@ -37,7 +37,9 @@ import scala.concurrent.ExecutionContext
  * @tparam S the aggregate state type
  */
 
-abstract class KafkaPublisher[S <: scalapb.GeneratedMessage](encryptionAdapter: EncryptionAdapter)(implicit
+abstract class KafkaPublisher[S <: scalapb.GeneratedMessage](encryptionAdapter: EncryptionAdapter,
+                                                             protosRegistry: ProtosRegistry
+)(implicit
   ec: ExecutionContext,
   actorSystem: ActorSystem[_]
 ) extends EventProcessor {
@@ -77,7 +79,7 @@ abstract class KafkaPublisher[S <: scalapb.GeneratedMessage](encryptionAdapter: 
               new ProducerRecord(
                 producerConfig.topic,
                 comp.parseFrom(event.value.toByteArray).getField(fd).as[String],
-                ProtosRegistry.printer.print(
+                protosRegistry.printer.print(
                   KafkaEvent.defaultInstance
                     .withEvent(event)
                     .withState(StateWrapper().withMeta(meta).withState(resultingState))
@@ -121,7 +123,7 @@ abstract class KafkaPublisher[S <: scalapb.GeneratedMessage](encryptionAdapter: 
               EventSourcedProvider
                 .eventsByTag[EventWrapper](actorSystem, readJournalPluginId = JdbcReadJournal.Identifier, tagName),
               offsetStoreDatabaseConfig,
-              handler = () => new EventsReader(tagName, this, encryptionAdapter)
+              handler = () => new EventsReader(tagName, this, encryptionAdapter, protosRegistry)
             )
         )
       },

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/KafkaPublisher.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/KafkaPublisher.scala
@@ -37,9 +37,7 @@ import scala.concurrent.ExecutionContext
  * @tparam S the aggregate state type
  */
 
-abstract class KafkaPublisher[S <: scalapb.GeneratedMessage](encryptionAdapter: EncryptionAdapter,
-                                                             protosRegistry: ProtosRegistry
-)(implicit
+abstract class KafkaPublisher[S <: scalapb.GeneratedMessage](encryptionAdapter: EncryptionAdapter)(implicit
   ec: ExecutionContext,
   actorSystem: ActorSystem[_]
 ) extends EventProcessor {
@@ -79,7 +77,7 @@ abstract class KafkaPublisher[S <: scalapb.GeneratedMessage](encryptionAdapter: 
               new ProducerRecord(
                 producerConfig.topic,
                 comp.parseFrom(event.value.toByteArray).getField(fd).as[String],
-                protosRegistry.printer.print(
+                ProtosRegistry.printer.print(
                   KafkaEvent.defaultInstance
                     .withEvent(event)
                     .withState(StateWrapper().withMeta(meta).withState(resultingState))
@@ -123,7 +121,7 @@ abstract class KafkaPublisher[S <: scalapb.GeneratedMessage](encryptionAdapter: 
               EventSourcedProvider
                 .eventsByTag[EventWrapper](actorSystem, readJournalPluginId = JdbcReadJournal.Identifier, tagName),
               offsetStoreDatabaseConfig,
-              handler = () => new EventsReader(tagName, this, encryptionAdapter, protosRegistry)
+              handler = () => new EventsReader(tagName, this, encryptionAdapter)
             )
         )
       },

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/ReadSideProcessor.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/ReadSideProcessor.scala
@@ -13,7 +13,7 @@ import akka.projection.scaladsl.{ExactlyOnceProjection, SourceProvider}
 import akka.projection.slick.SlickProjection
 import com.github.ghik.silencer.silent
 import com.google.protobuf.any
-import io.superflat.lagompb.ConfigReader
+import io.superflat.lagompb.{ConfigReader, ProtosRegistry}
 import io.superflat.lagompb.encryption.EncryptionAdapter
 import io.superflat.lagompb.protobuf.v1.core.{EventWrapper, MetaData}
 import org.slf4j.{Logger, LoggerFactory}
@@ -40,7 +40,9 @@ import scala.util.{Failure, Success, Try}
  * @param ec          the execution context
  * @tparam S the aggregate state type
  */
-@silent abstract class ReadSideProcessor[S <: scalapb.GeneratedMessage](encryptionAdapter: EncryptionAdapter)(implicit
+@silent abstract class ReadSideProcessor[S <: scalapb.GeneratedMessage](encryptionAdapter: EncryptionAdapter,
+                                                                        protosRegistry: ProtosRegistry
+)(implicit
   ec: ExecutionContext,
   actorSystem: ActorSystem[_]
 ) extends EventProcessor {
@@ -105,7 +107,7 @@ import scala.util.{Failure, Success, Try}
         projectionId = ProjectionId(projectionName, tagName),
         sourceProvider(tagName),
         offsetStoreDatabaseConfig,
-        handler = () => new EventsReader(tagName, this, encryptionAdapter)
+        handler = () => new EventsReader(tagName, this, encryptionAdapter, protosRegistry)
       )
 
   /**

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/ReadSideProcessor.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/ReadSideProcessor.scala
@@ -40,9 +40,7 @@ import scala.util.{Failure, Success, Try}
  * @param ec          the execution context
  * @tparam S the aggregate state type
  */
-@silent abstract class ReadSideProcessor[S <: scalapb.GeneratedMessage](encryptionAdapter: EncryptionAdapter,
-                                                                        protosRegistry: ProtosRegistry
-)(implicit
+@silent abstract class ReadSideProcessor[S <: scalapb.GeneratedMessage](encryptionAdapter: EncryptionAdapter)(implicit
   ec: ExecutionContext,
   actorSystem: ActorSystem[_]
 ) extends EventProcessor {
@@ -107,7 +105,7 @@ import scala.util.{Failure, Success, Try}
         projectionId = ProjectionId(projectionName, tagName),
         sourceProvider(tagName),
         offsetStoreDatabaseConfig,
-        handler = () => new EventsReader(tagName, this, encryptionAdapter, protosRegistry)
+        handler = () => new EventsReader(tagName, this, encryptionAdapter)
       )
 
   /**


### PR DESCRIPTION
Changes:
- base traits for command & event handlers with a "Simple" abstract class that unmarshals to provided proto classes
- eliminates custom unmarshaling in the command serializer and just uses an `Any` on the wire


resolves #163 