### PR TITLE
Separate TypedReadsideProcessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ project/metals.sbt
 *.iml
 .protogen/
 .vscode/
+metals.sbt

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/EventProcessor.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/EventProcessor.scala
@@ -1,20 +1,18 @@
 package io.superflat.lagompb.readside
 
 import akka.Done
-import com.google.protobuf.any
+import com.google.protobuf.any.Any
 import io.superflat.lagompb.protobuf.v1.core.MetaData
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 import slick.dbio.DBIO
+import io.superflat.lagompb.ProtosRegistry
+import scala.util.{Failure, Success}
 
-/**
- * Helps process the events read from the journal
- */
 trait EventProcessor {
 
   /**
    * Processes events read from the Journal
    *
-   * @param comp the scalapb companion object used to unmarshall the aggregate state
    * @param event the actual event
    * @param eventTag the event tag
    * @param resultingState the resulting state of the applied event
@@ -22,10 +20,9 @@ trait EventProcessor {
    * @return
    */
   def process(
-    comp: GeneratedMessageCompanion[_ <: GeneratedMessage],
-    event: any.Any,
+    event: Any,
     eventTag: String,
-    resultingState: any.Any,
+    resultingState: Any,
     meta: MetaData
   ): DBIO[Done]
 }

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/ReadSideEvent.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/ReadSideEvent.scala
@@ -1,6 +1,7 @@
 package io.superflat.lagompb.readside
 
 import io.superflat.lagompb.protobuf.v1.core.MetaData
+import com.google.protobuf.any.Any
 
 /**
  * Wraps events read from the journal and make it available to any consumer
@@ -9,11 +10,10 @@ import io.superflat.lagompb.protobuf.v1.core.MetaData
  * @param eventTag the event tag
  * @param state the resulting state of the event
  * @param metaData the additional metadata
- * @tparam S the resulting state scala type
  */
-case class ReadSideEvent[S <: scalapb.GeneratedMessage](
-  event: scalapb.GeneratedMessage,
+case class ReadSideEvent(
+  event: Any,
   eventTag: String,
-  state: S,
+  state: Any,
   metaData: MetaData
 )

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/TypedReadSideProcessor.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/TypedReadSideProcessor.scala
@@ -35,7 +35,7 @@ abstract class TypedReadSideProcessor(encryptionAdapter: EncryptionAdapter)(impl
   def handle(event: ReadSideEvent): DBIO[Done] = {
     ProtosRegistry.unpackAnys(event.event, event.state) match {
       case Failure(e) =>
-        throw e
+        DBIOAction.failed(e)
       case Success(messages) =>
         handleTyped(
           messages(0),

--- a/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/TypedReadSideProcessor.scala
+++ b/core/lagompb-readside/src/main/scala/io/superflat/lagompb/readside/TypedReadSideProcessor.scala
@@ -1,0 +1,55 @@
+package io.superflat.lagompb.readside
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.adapter._
+import com.google.protobuf.any.Any
+import slick.dbio.{DBIO, DBIOAction}
+import io.superflat.lagompb.ProtosRegistry
+import io.superflat.lagompb.encryption.EncryptionAdapter
+import io.superflat.lagompb.protobuf.v1.core.{MetaData}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+
+import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContext
+
+/**
+ * ReadSideProcessor that publishes to kafka
+ *
+ * @param encryptionAdapter EncryptionAdapter instance to use
+ * @param actorSystem the actor system
+ * @param ec the execution context
+ * @tparam S the aggregate state type
+ */
+
+abstract class TypedReadSideProcessor(encryptionAdapter: EncryptionAdapter)(implicit
+  ec: ExecutionContext,
+  actorSystem: ActorSystem[_]
+) extends ReadSideProcessor(encryptionAdapter) {
+
+  /**
+   * Handles aggregate event persisted and made available for read model
+   *
+   * @param event the aggregate event
+   */
+  def handle(event: ReadSideEvent): DBIO[Done] = {
+    ProtosRegistry.unpackAnys(event.event, event.state) match {
+      case Failure(e) =>
+        throw e
+      case Success(messages) =>
+        handleTyped(
+          messages(0),
+          event.eventTag,
+          messages(1),
+          event.metaData
+        )
+    }
+  }
+
+  def handleTyped(
+    event: GeneratedMessage,
+    eventTag: String,
+    state: GeneratedMessage,
+    metaData: MetaData
+  ): DBIO[Done]
+}


### PR DESCRIPTION
Makes the default read side processor use scalapb Any messages, and adds a child `TypedReadSideProcessor` abstract class for automatic unmarshalling of the event & state classes.

Changes:
- makes `ReadSideProcessor` default to scalapb `Any` for event & state
- adds `TypedReadSideProcessor` abstract class
- makes `KafkaPublisher` implement `TypedReadSideProcessor`