### PR TITLE
BugFix for sendCommand

### DIFF
--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
@@ -94,7 +94,10 @@ sealed trait SharedBaseServiceImpl {
           throw new GlobalException(exception.getMessage)
         case Success(value) => value
       }
-    else throw new GlobalException("wrong state definition")
+    else {
+
+      throw new GlobalException(s"wrong state definition, $typeUrl")
+    }
   }
 
   // $COVERAGE-ON$

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
@@ -44,13 +44,12 @@ sealed trait SharedBaseServiceImpl {
    * @param cmd        the command to send to the aggregate. It is a scalapb generated case class from the command
    *                   protocol buffer message definition
    * @param data       additional data that need to be set in the state meta
-   * @tparam C the Type of the command to send.
    * @return Future of state
    */
-  def sendCommand[C <: scalapb.GeneratedMessage, S <: scalapb.GeneratedMessage](
+  def sendCommand(
     clusterSharding: ClusterSharding,
     entityId: String,
-    cmd: C,
+    cmd: scalapb.GeneratedMessage,
     data: Map[String, String]
   )(implicit ec: ExecutionContext): Future[StateWrapper] = {
     clusterSharding
@@ -109,13 +108,13 @@ abstract class BaseServiceImpl(
    * @tparam S   the actual state scala type
    * @return the [[io.superflat.lagompb.StateAndMeta]] containing the actual state and the event meta
    */
-  final def sendCommand[C <: GeneratedMessage, S <: scalapb.GeneratedMessage](
+  final def sendCommand(
     entityId: String,
-    cmd: C,
+    cmd: GeneratedMessage,
     data: Map[String, String]
   ): Future[StateWrapper] = {
     super
-      .sendCommand[C, S](clusterSharding, entityId, cmd, data)
+      .sendCommand(clusterSharding, entityId, cmd, data)
       .transform {
         case Failure(exception) =>
           log.error("", exception)
@@ -151,14 +150,14 @@ trait BaseGrpcServiceImpl extends SharedBaseServiceImpl {
    * @tparam S   the actual state scala type
    * @return the [[io.superflat.lagompb.StateAndMeta]] containing the actual state and the state meta
    */
-  final override def sendCommand[C <: GeneratedMessage, S <: scalapb.GeneratedMessage](
+  final override def sendCommand(
     clusterSharding: ClusterSharding,
     entityId: String,
-    cmd: C,
+    cmd: GeneratedMessage,
     data: Map[String, String]
   )(implicit ec: ExecutionContext): Future[StateWrapper] =
     super
-      .sendCommand[C, S](clusterSharding, entityId, cmd, data)
+      .sendCommand(clusterSharding, entityId, cmd, data)
       .transform {
         case Failure(exception) =>
           exception match {

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
@@ -96,7 +96,7 @@ sealed trait SharedBaseServiceImpl {
       }
     else {
 
-      throw new GlobalException(s"wrong state definition, $typeUrl")
+      throw new GlobalException(s"wrong state definition, expecting ${aggregateStateCompanion.scalaDescriptor.fullName}, received $typeUrl")
     }
   }
 

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
@@ -40,10 +40,11 @@ sealed trait SharedBaseServiceImpl {
    * sends commands to the aggregate root and return a future of the aggregate state given a entity Id
    * the given entity Id is obtained the cluster shard.
    *
-   * @param entityId the entity Id added or retrieved from the shard
-   * @param cmd        the command to send to the aggregate. It is a scalapb generated case class from the command
-   *                   protocol buffer message definition
-   * @param data       additional data that need to be set in the state meta
+   * @param clusterSharding  an instance of ClusterSharding
+   * @param entityId         the entity Id added or retrieved from the shard
+   * @param cmd              the command to send to the aggregate. It is a scalapb generated case class from the command
+   *                         protocol buffer message definition
+   * @param data             additional data that need to be set in the state meta
    * @return Future of state
    */
   def sendCommand(
@@ -104,8 +105,6 @@ abstract class BaseServiceImpl(
    * @param entityId the entity ID
    * @param cmd      the command to send
    * @param data     the additional data to send
-   * @tparam C the command scala type
-   * @tparam S   the actual state scala type
    * @return the [[io.superflat.lagompb.StateAndMeta]] containing the actual state and the event meta
    */
   final def sendCommand(
@@ -146,8 +145,6 @@ trait BaseGrpcServiceImpl extends SharedBaseServiceImpl {
    * @param entityId        the entity ID
    * @param cmd             the command to send
    * @param data            the additional data to send
-   * @tparam C the command scala type
-   * @tparam S   the actual state scala type
    * @return the [[io.superflat.lagompb.StateAndMeta]] containing the actual state and the state meta
    */
   final override def sendCommand(

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/BaseServiceImpl.scala
@@ -52,19 +52,19 @@ sealed trait SharedBaseServiceImpl {
     entityId: String,
     cmd: C,
     data: Map[String, String]
-  )(implicit ec: ExecutionContext): Future[StateAndMeta[S]] = {
+  )(implicit ec: ExecutionContext): Future[StateWrapper] = {
     clusterSharding
       .entityRefFor(aggregateRoot.typeKey, entityId)
       .ask[CommandReply](replyTo => Command(Any.pack(cmd), replyTo, data))
-      .flatMap((value: CommandReply) => Future.fromTry(handleLagompbCommandReply[S](value)))
+      .flatMap((value: CommandReply) => Future.fromTry(handleLagompbCommandReply(value)))
   }
 
-  private[lagompb] def handleLagompbCommandReply[S <: scalapb.GeneratedMessage](
+  private[lagompb] def handleLagompbCommandReply(
     commandReply: CommandReply
-  ): Try[StateAndMeta[S]] =
+  ): Try[StateWrapper] =
     commandReply.reply match {
       case Reply.SuccessfulReply(successReply) =>
-        Success(parseState[S](successReply.getStateWrapper))
+        Success(successReply.getStateWrapper)
       case Reply.FailedReply(failureReply) =>
         failureReply.cause match {
           case FailureCause.VALIDATION_ERROR => Failure(new InvalidCommandException(failureReply.reason))
@@ -73,32 +73,6 @@ sealed trait SharedBaseServiceImpl {
         }
       case _ => Failure(new GlobalException(s"unknown CommandReply ${commandReply.reply.getClass.getName}"))
     }
-
-  private[lagompb] def parseState[S <: scalapb.GeneratedMessage](
-    stateWrapper: StateWrapper
-  ): StateAndMeta[S] = {
-    val meta: MetaData = stateWrapper.getMeta
-    val state: Any = stateWrapper.getState
-    val parsed: S = parseAny[S](state)
-    StateAndMeta[S](parsed, meta)
-  }
-
-  private[lagompb] def parseAny[S <: scalapb.GeneratedMessage](data: Any): S = {
-    val typeUrl: String = data.typeUrl.split('/').lastOption.getOrElse("")
-
-    if (aggregateStateCompanion.scalaDescriptor.fullName === typeUrl)
-      Try {
-        data.unpack(aggregateStateCompanion).asInstanceOf[S]
-      } match {
-        case Failure(exception) =>
-          throw new GlobalException(exception.getMessage)
-        case Success(value) => value
-      }
-    else {
-
-      throw new GlobalException(s"wrong state definition, expecting ${aggregateStateCompanion.scalaDescriptor.fullName}, received $typeUrl")
-    }
-  }
 
   // $COVERAGE-ON$
 }
@@ -128,40 +102,6 @@ abstract class BaseServiceImpl(
    * Sends command to the aggregate root. The command must have the aggregate entity id set.
    * When the entity id is not set a BadRequest is sent to the api
    *
-   * @param cmd  the command to send
-   * @param data the additional data to send
-   * @tparam C the command scala type
-   * @tparam S   the actual state scala type
-   * @return the [[io.superflat.lagompb.StateAndMeta]] containing the actual state and the event meta
-   */
-  final def sendCommand[C <: GeneratedMessage, S <: scalapb.GeneratedMessage](
-    cmd: C,
-    data: Map[String, String] = Map.empty
-  ): Future[StateAndMeta[S]] =
-    cmd.companion.scalaDescriptor.fields
-      .find(field => field.getOptions.extension(ExtensionsProto.command).exists(_.entityId))
-      .fold[Future[StateAndMeta[S]]](Future.failed(BadRequest("entity key not set."))) { fd =>
-        val entityId: String = cmd.getField(fd).as[String]
-        super
-          .sendCommand[C, S](clusterSharding, entityId, cmd, data)
-          .transform {
-            case Failure(exception) =>
-              log.error("", exception)
-              exception match {
-                case e: GlobalException =>
-                  Failure(InternalServerError(e.getMessage))
-                case e: InvalidCommandException =>
-                  Failure(BadRequest(e.getMessage))
-                case _ => Failure(InternalServerError(""))
-              }
-            case Success(value) => Success(value)
-          }
-      }
-
-  /**
-   * Sends command to the aggregate root. The command must have the aggregate entity id set.
-   * When the entity id is not set a BadRequest is sent to the api
-   *
    * @param entityId the entity ID
    * @param cmd      the command to send
    * @param data     the additional data to send
@@ -173,7 +113,7 @@ abstract class BaseServiceImpl(
     entityId: String,
     cmd: C,
     data: Map[String, String]
-  ): Future[StateAndMeta[S]] =
+  ): Future[StateWrapper] = {
     super
       .sendCommand[C, S](clusterSharding, entityId, cmd, data)
       .transform {
@@ -187,7 +127,9 @@ abstract class BaseServiceImpl(
             case _ => Failure(InternalServerError(""))
           }
         case Success(value) => Success(value)
+
       }
+  }
 }
 
 /**
@@ -214,7 +156,7 @@ trait BaseGrpcServiceImpl extends SharedBaseServiceImpl {
     entityId: String,
     cmd: C,
     data: Map[String, String]
-  )(implicit ec: ExecutionContext): Future[StateAndMeta[S]] =
+  )(implicit ec: ExecutionContext): Future[StateWrapper] =
     super
       .sendCommand[C, S](clusterSharding, entityId, cmd, data)
       .transform {
@@ -229,50 +171,6 @@ trait BaseGrpcServiceImpl extends SharedBaseServiceImpl {
               Failure(new GrpcServiceException(status = Status.INTERNAL))
           }
         case Success(value) => Success(value)
-      }
-
-  /**
-   * Sends command to the aggregate root. The command must have the aggregate entity id set.
-   * When the entity id is not set a INVALID_ARGUMENT is sent to the gRPC client
-   *
-   * @param clusterSharding the cluster sharding
-   * @param cmd             the command to send
-   * @param data            the additional data to send
-   * @tparam C the command scala type
-   * @tparam S   the actual state scala type
-   * @return the [[io.superflat.lagompb.StateAndMeta]] containing the actual state and the state meta
-   */
-  final def sendCommand[C <: GeneratedMessage, S <: scalapb.GeneratedMessage](
-    clusterSharding: ClusterSharding,
-    cmd: C,
-    data: Map[String, String]
-  )(implicit ec: ExecutionContext): Future[StateAndMeta[S]] =
-    cmd.companion.scalaDescriptor.fields
-      .find(field => field.getOptions.extension(ExtensionsProto.command).exists(_.entityId))
-      .fold[Future[StateAndMeta[S]]](
-        Future.failed(
-          new GrpcServiceException(
-            status = Status.INVALID_ARGUMENT
-              .withDescription("entity key not set.")
-          )
-        )
-      ) { fd =>
-        val entityId: String = cmd.getField(fd).as[String]
-        super
-          .sendCommand[C, S](clusterSharding, entityId, cmd, data)
-          .transform {
-            case Failure(exception) =>
-              exception match {
-                case e: GlobalException =>
-                  Failure(new GrpcServiceException(status = Status.INTERNAL.withDescription(e.getMessage)))
-                case e: GrpcServiceException => Failure(e)
-                case e: InvalidCommandException =>
-                  Failure(new GrpcServiceException(status = Status.INVALID_ARGUMENT.withDescription(e.getMessage)))
-                case _ =>
-                  Failure(new GrpcServiceException(status = Status.INTERNAL))
-              }
-            case Success(value) => Success(value)
-          }
       }
 
   // $COVERAGE-ON$

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/StateAndMeta.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/StateAndMeta.scala
@@ -1,6 +1,7 @@
 package io.superflat.lagompb
 
 import io.superflat.lagompb.protobuf.v1.core.MetaData
+import com.google.protobuf.any.Any
 
 /**
  * StateAndMeta wraps the actual aggregate state with some meta data about the state
@@ -9,4 +10,4 @@ import io.superflat.lagompb.protobuf.v1.core.MetaData
  * @param metaData the state meta
  * @tparam A state scala type
  */
-final case class StateAndMeta[A](state: A, metaData: MetaData)
+final case class StateAndMeta[A](state: Any, metaData: MetaData)

--- a/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestService.scala
+++ b/core/lagompb-core/src/test/scala/io/superflat/lagompb/data/TestService.scala
@@ -13,6 +13,7 @@ import io.superflat.lagompb.protobuf.v1.tests.{TestCmd, TestState}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.concurrent.ExecutionContext
+import io.superflat.lagompb.protobuf.v1.core.StateWrapper
 
 trait TestService extends BaseService {
 
@@ -44,7 +45,7 @@ class TestServiceImpl(
   override def testHello: ServiceCall[TestCmd, TestState] = { req =>
     val companyId: String = UUID.randomUUID().toString
     val cmd = req.update(_.companyUuid := companyId)
-    sendCommand[TestCmd, TestState](companyId, cmd, Map.empty[String, String])
-      .map((rst: StateAndMeta[TestState]) => rst.state)
+    sendCommand(companyId, cmd, Map.empty[String, String])
+      .map((rst: StateWrapper) => rst.state.get.unpack(TestState))
   }
 }


### PR DESCRIPTION
This PR makes `sendCommand` return the lagom-pb `StateWrapper` directly, instead of the StateAndMeta object. We observed the prior changes (to use `Any`) broke some validations in the response handler after sendCommand, as it was trying to validate the typeUrl of the nested state message, while the aggregate root was expecting a state of type `Any`.

If we want to support this dynamic unpacking of state, we should follow the pattern of a separate method like `sendCommandTyped`