### PR TITLE
enable/disable snapshot and auto-delete events on snapshot persistence

### DIFF
--- a/core/lagompb-core/src/main/resources/lagompb.conf
+++ b/core/lagompb-core/src/main/resources/lagompb.conf
@@ -443,12 +443,20 @@ lagompb {
   ask-timeout = 5
 
   snapshot-criteria {
+    #  Snapshots are not saved and deleted automatically, events are not deleted
+    disable-snapshot = false
+    disable-snapshot = ${?DISABLE_SNAPSHOT}
     # number of events to batch persist
     frequency = 100
     frequency = ${?EVENTS_BATCH_THRESHOLD}
     # number of snapshots to retain
     retention = 2
     retention = ${?NUM_SNAPSHOTS_TO_RETAIN}
+    # this feature allow to clean the journal history
+    # Event deletion is triggered after saving a new snapshot. Old events would be deleted prior to old snapshots being deleted
+    # reference: https://doc.akka.io/docs/akka/current/typed/persistence-snapshot.html#event-deletion
+    delete-events-on-snapshot = false
+    delete-events-on-snapshot = ${?DELETE_EVENTS_ON_SNAPSHOT}
   }
 
   events {

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/ConfigReader.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/ConfigReader.scala
@@ -5,7 +5,12 @@ import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.concurrent.duration._
 
-final case class SnapshotCriteria(frequency: Int, retention: Int)
+final case class SnapshotCriteria(
+    frequency: Int,
+    retention: Int,
+    deleteEventsOnSnapshot: Boolean,
+    disableSnapshot: Boolean
+)
 
 final case class EventsConfig(tagName: String, numShards: Int)
 
@@ -23,7 +28,9 @@ object ConfigReader {
   def snapshotCriteria: SnapshotCriteria =
     SnapshotCriteria(
       frequency = config.getInt(s"$LP.snapshot-criteria.frequency"),
-      retention = config.getInt(s"$LP.snapshot-criteria.retention")
+      retention = config.getInt(s"$LP.snapshot-criteria.retention"),
+      deleteEventsOnSnapshot = config.getBoolean(s"$LP.snapshot-criteria.delete-events-on-snapshot"),
+      disableSnapshot = config.getBoolean(s"$LP.snapshot-criteria.disable-snapshot")
     )
 
   def allEventTags: Vector[String] =


### PR DESCRIPTION
Two different config settings

- `delete-events-on-snapshot`: Event deletion is triggered after saving a new snapshot. Old events would be deleted prior to old snapshots being deleted.

- `disable-snapshot`:  Snapshots are not saved and deleted automatically, events are not deleted