### PR TITLE
Allow override create event sourced behavior

### DIFF
--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -81,7 +81,7 @@ abstract class AggregateRoot(
    *
    * @param persistenceId the aggregate persistence Id
    */
-  protected[lagompb] def create(
+  protected def create(
       persistenceId: PersistenceId
   ): EventSourcedBehavior[Command, EventWrapper, StateWrapper] = {
     val splitter: Char = PersistenceId.DefaultSeparator(0)

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -81,7 +81,7 @@ abstract class AggregateRoot(
    *
    * @param persistenceId the aggregate persistence Id
    */
-  private[lagompb] def create(
+  protected[lagompb] def create(
       persistenceId: PersistenceId
   ): EventSourcedBehavior[Command, EventWrapper, StateWrapper] = {
     val splitter: Char = PersistenceId.DefaultSeparator(0)

--- a/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
+++ b/core/lagompb-core/src/main/scala/io/superflat/lagompb/AggregateRoot.scala
@@ -81,7 +81,7 @@ abstract class AggregateRoot(
    *
    * @param persistenceId the aggregate persistence Id
    */
-  protected def create(
+  protected[lagompb] def create(
       persistenceId: PersistenceId
   ): EventSourcedBehavior[Command, EventWrapper, StateWrapper] = {
     val splitter: Char = PersistenceId.DefaultSeparator(0)


### PR DESCRIPTION
Converts `.create` method that returns EventSourcedBehavior from `private` to `protected` so subclasses can override.